### PR TITLE
Update test command, add editorconfig

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,23 @@
+root = true
+
+[*]
+indent_style = tab
+indent_size = 4
+charset = utf-8
+trim_trailing_whitespace = true
+insert_final_newline = true
+max_line_length = 233
+
+[*.js]
+end_of_line = lf
+
+[*.json]
+indent_style = space
+indent_size = 2
+
+[*.yml]
+indent_style = space
+indent_size = 2
+
+[*.md]
+trim_trailing_whitespace = false

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "license": "MIT",
   "scripts": {
     "lint": "eslint *.js",
-    "test": "ava"
+    "test": "ava --verbose"
   },
   "dependencies": {
     "webpack-addons": "^1.1.5",


### PR DESCRIPTION
Better output with `--version` flag

Good job adding tests. :fire: :100: 

Also, added editorconfig from [webpack-cli](https://github.com/webpack/webpack-cli/blob/master/.editorconfig)

![screenshot_20180223_173339](https://user-images.githubusercontent.com/5961873/36593442-ba3b3658-18bf-11e8-8ec6-9074ef143cd8.png)
